### PR TITLE
rip algolia and use luna instead 

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,7 +129,7 @@ github_branch= "main"
 algolia_docsearch = false
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
As of now Algolia links to our main docs (docs.localstack.cloud) which is not optimal. We're on a free plan, hence we can use Luna for offline searches without using any SaaS tooling. We can re-think adding Algolia back in, if they allow us to use more projects.

![image](https://github.com/localstack/snowflake-docs/assets/47351025/87f208b6-e043-4116-a67d-cdd3c5620c99)
