### PR TITLE
Lock Snowflake Terraform provider version

### DIFF
--- a/content/en/user-guide/integrations/terraform/index.md
+++ b/content/en/user-guide/integrations/terraform/index.md
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     snowflake = {
       source  = "Snowflake-Labs/snowflake"
-      version = "~> 0.61"
+      version = "= 0.92"
     }
   }
 }


### PR DESCRIPTION
Locking version due to:
- The ~> operator is a pessimistic version constraint, which allows for automatic installation of newer minor releases. In this case, it can lead to unintended version changes, potentially causing inconsistent behavior across different versions. You can find more information [here](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-syntax)