### PR TITLE
Update docs for node.js client

### DIFF
--- a/content/en/user-guide/snowflake-drivers/index.md
+++ b/content/en/user-guide/snowflake-drivers/index.md
@@ -61,6 +61,8 @@ var connection = snowflake.createConnection({
     password: 'test',
     account: 'test',
     database: 'test',
+    // snowflake-sdk version 1.9.3 and later supports host property and can be used instead of accessUrl like: host: 'snowflake.localhost.localstack.cloud',
+    // host: 'snowflake.localhost.localstack.cloud',
     accessUrl: 'https://snowflake.localhost.localstack.cloud',
 });
 connection.connect(function(err, conn) {

--- a/content/en/user-guide/snowflake-drivers/index.md
+++ b/content/en/user-guide/snowflake-drivers/index.md
@@ -61,7 +61,7 @@ var connection = snowflake.createConnection({
     password: 'test',
     account: 'test',
     database: 'test',
-    // snowflake-sdk version 1.9.3 and later supports host property and can be used instead of accessUrl like: host: 'snowflake.localhost.localstack.cloud',
+    // snowflake-sdk version 1.9.3 and later supports host property and can be used instead of accessUrl like:
     // host: 'snowflake.localhost.localstack.cloud',
     accessUrl: 'https://snowflake.localhost.localstack.cloud',
 });

--- a/content/en/user-guide/snowflake-drivers/index.md
+++ b/content/en/user-guide/snowflake-drivers/index.md
@@ -61,7 +61,7 @@ var connection = snowflake.createConnection({
     password: 'test',
     account: 'test',
     database: 'test',
-    host: 'snowflake.localhost.localstack.cloud',
+    accessUrl: 'https://snowflake.localhost.localstack.cloud',
 });
 connection.connect(function(err, conn) {
   if (err) {


### PR DESCRIPTION
The `host` connection parameter was introduced in [version 1.9.3](https://docs.snowflake.com/en/release-notes/clients-drivers/nodejs-2024#version-1-9-3-january-17-2024), meaning this sample will not work with earlier versions.

To ensure compatibility across all versions, including those before 1.9.3, it's safer to use the `accessUrl` parameter instead.